### PR TITLE
fix: Fix system_fake include dir not correct

### DIFF
--- a/cxx/cppast_backend/src/main.cc
+++ b/cxx/cppast_backend/src/main.cc
@@ -155,14 +155,6 @@ int main(int argc, char **argv) {
   include_header_dirs.push_back(tmp_path.c_str());
 
   if (parse_result.count("include-header-dirs")) {
-    auto include_system_dir = std::string(project_path
-                                          + "/../../../cxx-parser/cxx/"
-                                            "cppast_backend/"
-                                            "include/system_fake");
-    include_header_dirs.push_back(include_system_dir);
-
-    std::cout << "/include/system dir: " << include_system_dir << std::endl;
-
     include_header_dirs.push_back(
         "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/"
         "Developer/SDKs/MacOSX.sdk/usr/include");

--- a/package-lock.json
+++ b/package-lock.json
@@ -1218,9 +1218,9 @@
       "integrity": "sha512-5qcvofLPbfjmBfKaLfj/+f+Sbd6pN4zl7w7VSVI5uz7m9QZTuB2aZAa2uo1wHFBNN2x6g/SoTkXmd8mQnQF2Cw=="
     },
     "node_modules/acorn": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
-      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
+      "version": "8.11.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
+      "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1229,9 +1229,9 @@
       }
     },
     "node_modules/acorn-walk": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.0.tgz",
+      "integrity": "sha512-FS7hV565M5l1R08MXqo8odwMTB02C2UqzB17RVgu9EyuYFBqJZ3/ZY97sQD5FewVu1UyDFc1yztUDrAwT0EypA==",
       "engines": {
         "node": ">=0.4.0"
       }
@@ -1768,9 +1768,9 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.567",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.567.tgz",
-      "integrity": "sha512-8KR114CAYQ4/r5EIEsOmOMqQ9j0MRbJZR3aXD/KFA8RuKzyoUB4XrUCg+l8RUGqTVQgKNIgTpjaG8YHRPAbX2w=="
+      "version": "1.4.568",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.568.tgz",
+      "integrity": "sha512-3TCOv8+BY6Ltpt1/CmGBMups2IdKOyfEmz4J8yIS4xLSeMm0Rf+psSaxLuswG9qMKt+XbNbmADybtXGpTFlbDg=="
     },
     "node_modules/emittery": {
       "version": "0.13.1",

--- a/src/legacy_cxx_parser.ts
+++ b/src/legacy_cxx_parser.ts
@@ -19,6 +19,15 @@ export function runAgoraRtcAstBash(
   let module = "@agoraio-extensions/cxx-parser";
   let cxxParserModulePath = require.resolve(`${module}/package.json`);
   let terraPath = path.join(path.dirname(cxxParserModulePath), "cxx", "terra");
+  // <project>/node_modules/@agoraio-extensions/cxx-parser/cxx/cppast_backend/include/system_fake
+  let systemInclude = path.join(
+    path.dirname(cxxParserModulePath),
+    "cxx",
+    "cppast_backend",
+    "include",
+    "system_fake"
+  );
+  includeHeaderDirs.push(systemInclude);
 
   let buildDir = path.join(terraBuildDir, "legacy-cxx-parser");
   if (!fs.existsSync(buildDir)) {


### PR DESCRIPTION
Get the `system_fake` from the `<project>/node_modules/@agoraio-extensions/cxx-parser/cxx/cppast_backend/include/system_fake`, and pass it through the command line arg `includeHeaderDirs `