### PR TITLE
fix: Fix files order when call LegacyCXXParserConfigs.resolve

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agoraio-extensions/terra-legacy-cxx-parser",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "",
   "main": "src/index",
   "scripts": {

--- a/src/legacy_cxx_parser_configs.ts
+++ b/src/legacy_cxx_parser_configs.ts
@@ -21,25 +21,29 @@ export class LegacyCXXParserConfigs {
       language: original.language,
       includeHeaderDirs: original.includeHeaderDirs
         .map((it) => {
-          return globSync(resolvePath(it, configDir));
+          // The files order will descend when using globSync. So we sort the files to ensure the order.
+          return globSync(resolvePath(it, configDir)).sort();
         })
         .flat(1),
       definesMacros: original.definesMacros ?? [],
       parseFiles: {
         include: (original.parseFiles.include ?? [])
           .map((it) => {
-            return globSync(resolvePath(it, configDir));
+            // The files order will descend when using globSync. So we sort the files to ensure the order.
+            return globSync(resolvePath(it, configDir)).sort();
           })
           .flat(1),
         exclude: (original.parseFiles.exclude ?? [])
           .map((it) => {
-            return globSync(resolvePath(it, configDir));
+            // The files order will descend when using globSync. So we sort the files to ensure the order.
+            return globSync(resolvePath(it, configDir)).sort();
           })
           .flat(1),
       },
       customHeaders: original.customHeaders
         .map((it) => {
-          return globSync(resolvePath(it, configDir));
+          // The files order will descend when using globSync. So we sort the files to ensure the order.
+          return globSync(resolvePath(it, configDir)).sort();
         })
         .flat(1),
       legacyFlags: original.legacyFlags,


### PR DESCRIPTION
The file order will descend when using globSync. So we sorted the files to ensure the order.